### PR TITLE
Add Hide Content Export Branding

### DIFF
--- a/branding/javascript/hide_content_exports_for_teachers/README.md
+++ b/branding/javascript/hide_content_exports_for_teachers/README.md
@@ -1,3 +1,8 @@
 # Hide Content Exports Page for Teachers
 
 This snippet will replace the contents of the content export page with a message that the page is only available to administrators. This will remove the form to export content and the historic course content. It will not prevent teachers from using the API or other methods to export course content.
+
+## Support
+This is an unsupported, community-created project. Keep that in mind. Instructure won't be able to help you fix or debug this. That said, the community will hopefully help support and keep both the script and this documentation up-to-date.
+
+Functional as of 8/13/18

--- a/branding/javascript/hide_content_exports_for_teachers/README.md
+++ b/branding/javascript/hide_content_exports_for_teachers/README.md
@@ -1,0 +1,3 @@
+# Hide Content Exports Page for Teachers
+
+This snippet will replace the contents of the content export page with a message that the page is only available to administrators. This will remove the form to export content and the historic course content. It will not prevent teachers from using the API or other methods to export course content.

--- a/branding/javascript/hide_content_exports_for_teachers/hide-teacher-export-content.js
+++ b/branding/javascript/hide_content_exports_for_teachers/hide-teacher-export-content.js
@@ -1,0 +1,5 @@
+if (window.location.href.indexOf("/content_exports") > -1) {
+	if(ENV.current_user_roles.indexOf('admin') < 0) {
+	  $('#content').html('<h1>Unauthorized</h1><div>This page is only available to adminstrators.</div>');
+	}
+}


### PR DESCRIPTION
Pull request adds another branding snippet to hide the content exports page from all users that are not administrators.