### PR TITLE
Add grade policy crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Temporary Items
 *.pyo
 api/update_user_sis_ids/ruby/vendor
 env
+
+
+#NodeJS
+node_modules/

--- a/non_api/updateCourseGradingPolicies/README.md
+++ b/non_api/updateCourseGradingPolicies/README.md
@@ -1,0 +1,17 @@
+#Bulk update all course grading policies to manual
+This script was made to use a headless browser to crawl through a canvas site and update all course grading policies manually based on a list of course SIS IDs. 
+
+The headless browser approach was used because there was no way to do this through the api at the point of this script being written (hopefully there is something in the future).
+
+Make sure you have installed NodeJS and the script dependencies before running the script otherwise you will get errors!
+
+
+## Support
+This script is provided AS-IS, without warranty, and without any support beyond this
+document and anyone kind enough to help from the community.
+
+This is an unsupported, community-created project. Keep that in mind. Instructure won't be
+able to help you fix or debug this. That said, the community will hopefully help support
+and keep both the script and this documentation up-to-date.
+
+Good luck!

--- a/non_api/updateCourseGradingPolicies/README.md
+++ b/non_api/updateCourseGradingPolicies/README.md
@@ -1,4 +1,4 @@
-#Bulk update all course grading policies to manual
+# Bulk update all course grading policies to manual
 This script was made to use a headless browser to crawl through a canvas site and update all course grading policies manually based on a list of course SIS IDs. 
 
 The headless browser approach was used because there was no way to do this through the api at the point of this script being written (hopefully there is something in the future).

--- a/non_api/updateCourseGradingPolicies/index.js
+++ b/non_api/updateCourseGradingPolicies/index.js
@@ -1,0 +1,53 @@
+const fs = require("fs-extra");
+const request = require("request-promise");
+const async = require("async");
+const path = require("path");
+const _ = require("underscore");
+const puppeteer = require("puppeteer");
+
+/***           Canvas Webcrawler 
+            
+Crawls through each course on your canvas site that you 
+list and then switches on the manual grading posting
+policy for each course.
+Written in NodeJS by Robert Payne (rpaynelms@gmail.com)
+Working as of 03/03/2020
+
+Remember to run 'npm install' before running this script ('node index.js')
+
+    HEADLESS BRROWSING VARIABLES      **/
+const siteBase = "https://YOURSITE.instructure.com";
+const userName = "USERNAME";
+const pass = "PASSWORD";
+const headlessBool = false; //false if you want to watch, true if you don't
+var courseList = ["course1","course2","course3","course4","course5","course6","course7"] //sis ids for all courses you want to update
+
+crawl(); //it begins
+async function crawl() {
+	const loginP = siteBase + "/login/canvas/";
+	const browser = await puppeteer.launch({ headless: headlessBool });//Start headless browser
+	const page = await browser.newPage();
+	await page.setViewport({width:2000,height:1200});
+	
+	//Login
+    await page.goto(loginP); 
+    await page.type("#pseudonym_session_unique_id", userName);
+    await page.type("#pseudonym_session_password", pass);
+	await page.click(".Button");
+	
+	//Go through the courses
+	for(var course in courseList){ 
+		console.log(courseList[course]);
+		await page.goto(siteBase+"/courses/sis_course_id:"+courseList[course]+"/gradebook", {waitUntil: 'networkidle0',});
+		await page.click("#gradebook-settings-button");
+		await page.waitFor(1000);
+		await page.click("[role='tab']:nth-child(2)");
+		await page.waitFor(2000);
+		await page.click('#GradePostingPolicyTabPanel__PostManually');
+		await page.waitFor(2000);
+		await page.click('#gradebook-settings-update-button');	
+		await page.waitFor(4000);		
+	}
+	
+	await browser.close();
+}


### PR DESCRIPTION
Added a script we used to bulk update course grading policies to "manual grading policy".
Done with NodeJS headless browser instead of API since there is no way to do this through APIs at the moment.