### PR TITLE
+ JS snippet to hide the Conferences course nav link

### DIFF
--- a/branding/javascript/hide_conferences_course_nav/README.md
+++ b/branding/javascript/hide_conferences_course_nav/README.md
@@ -1,0 +1,14 @@
+# Hide Conferences Course Navigation Link
+
+This option hides the "Conferences" course navigation link in all courses for all users, as well as the "Conferences" navigation item in the course navigation configuration interface.
+
+**Note**: As with any part of Canvas, the links that these CSS rules target could change at any time. Be sure to check your beta environment before each production release to be sure that none of your CSS has broken due to an upcoming code change.
+
+## Support
+
+This is an unsupported, community-created project. Keep that in mind.
+Instructure won't be able to help you fix or debug this. That said, the
+community will hopefully help support and keep both the script and this
+documentation up-to-date.
+
+Good luck!

--- a/branding/javascript/hide_conferences_course_nav/hide_conferences_course_nav.js
+++ b/branding/javascript/hide_conferences_course_nav/hide_conferences_course_nav.js
@@ -1,0 +1,20 @@
+// Working as of 7/28/2020
+
+function onElementRendered(selector, cb, _attempts) {
+  var el = $(selector);
+  _attempts = ++_attempts || 1;
+  if (el.length) return cb(el);
+  if (_attempts == 60) return;
+  setTimeout(function () {
+    onElementRendered(selector, cb, _attempts);
+  }, 250);
+}
+
+// When element is rendered, the targeted element will be hidden
+onElementRendered(".conferences", function (e) {
+  $(".conferences").hide();
+});
+
+onElementRendered("[aria-label='Conferences']", function (e) {
+  $("[aria-label='Conferences']").hide();
+});


### PR DESCRIPTION
Adding JS to hide the "Conferences" course navigation link. Also hides the Conferences tile in the course navigation interface so that it can't be added and then cause more confusion.

Use Case: Some institutions use other LTI tools for conferencing (such as Teams, Zoom), and hiding the link for "Conferences" in the course navigation has been requested.